### PR TITLE
Fix "intent is not a function" error in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ function routing(intent) {
 }
 
 function main(sources) {
-  var intent = intent(sources);
+  var intentions = intent(sources);
   return {
-    DOM: view(model(intent)),
-    router: routing(intent)
+    DOM: view(model(intentions)),
+    router: routing(intentions)
   };
 }
 

--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ function view(model$) {
   });
 }
 
-function routing(intent) {
-  return intent.clickStart$
+function routing(actions) {
+  return actions.clickStart$
     .map(ev => 'start'); // could also be ['start'] or ['start', arg1, ...]
 }
 
 function main(sources) {
-  var intentions = intent(sources);
+  var actions = intent(sources);
   return {
-    DOM: view(model(intentions)),
-    router: routing(intentions)
+    DOM: view(model(actions)),
+    router: routing(actions)
   };
 }
 


### PR DESCRIPTION
Example code is broken because of variable redeclaration.
`intent` function return `intentions` object (not `intent`).
